### PR TITLE
Add setting to allow synchronous remote calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ You now interact with `Totango.client` to do your bidding:
       :module => "Current module"
     })
 
+By default, Totango will create a new thread to make the remote calls. If you already track the events using a background job, you should use synchronous calls. To turn synchronous calls on, use `Totango::Config`:
+
+    Totango::Config[:synchronous] = true
+
 There is also the option for integration with different ruby frameworks.
 
 ### Rails

--- a/lib/totango/client.rb
+++ b/lib/totango/client.rb
@@ -33,12 +33,10 @@ module Totango
       url = build_url(data)
 
       if Totango.on?
-        Thread.new do
-          begin
-            open(url)
-          rescue => e
-            STDERR.puts "[Totango] ERROR making call to Totango: #{e.class} ~> #{e.message}"
-          end
+        if Config[:synchronous]
+          send(url)
+        else
+          Thread.new { send(url) }
         end
       else
         unless Config[:suppress_output]
@@ -49,6 +47,14 @@ module Totango
 
     def build_url(data)
       [BASE_URI, @srv_id, "&", ArgParser.parse(data).to_params].join
+    end
+
+    def send(url)
+      begin
+        open(url)
+      rescue => e
+        STDERR.puts "[Totango] ERROR making call to Totango: #{e.class} ~> #{e.message}"
+      end
     end
   end
 end

--- a/lib/totango/config.rb
+++ b/lib/totango/config.rb
@@ -4,7 +4,8 @@ module Totango
       def defaults
         @defaults ||= {
           :on => false,
-          :suppress_output => false
+          :suppress_output => false,
+          :synchronous => false
         }
       end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -89,6 +89,34 @@ describe Totango::Client do
           end
         end
       end
+
+      context "when turned on" do
+        before do
+          Totango::Config[:on] = true
+        end
+
+        context "when using synchronous requests" do
+          before do
+            Totango::Config[:synchronous] = true
+          end
+
+          it "doesn't create a new thread" do
+            Thread.should_receive(:new).never
+            Totango.track :a => "hello thar"
+          end
+        end
+
+        context "when using asynchronous requests" do
+          before do
+            Totango::Config[:synchronous] = false
+          end
+
+          it "creates a new thread" do
+            Thread.should_receive(:new).once
+            Totango.track :a => "hello thar"
+          end
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Currently a new thread is created to make the remote calls, but if you already track the events using a background job you don't need to create new threads and it's possible that the worker process is 'done' and thus getting killed off before the remote call is made (we were experiencing this problem in the company i work for and this change solved it).

This PR provides a 'synchronous' setting to configure that. To turn synchronous calls on:

```
Totango::Config[:synchronous] = true
```
