### PR TITLE
Support "Organization Foreign ID (ofid)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ You now interact with `Totango.client` to do your bidding:
       :module => "Current module"
     })
 
+You can optionally pass a 'Foreign ID' to Activity Events to indicate the Organization’s identifier on foreign systems:
+
+    Totango.client.track({
+      :organization => "Current organization",
+      :user => "Current user",
+      :activity => "Current activity",
+      :module => "Current module",
+      :ofid => "1234"
+    })
+
 By default, Totango will create a new thread to make the remote calls. If you already track the events using a background job, you should use synchronous calls. To turn synchronous calls on, use `Totango::Config`:
 
     Totango::Config[:synchronous] = true

--- a/lib/totango/arg_parser.rb
+++ b/lib/totango/arg_parser.rb
@@ -41,6 +41,7 @@ module Totango
     parses_arg :sdr_o, :o, :org, :organization
     parses_arg :sdr_m, :m, :mod, :module
     parses_arg :sdr_u, :u, :user
+    parses_arg :sdr_ofid, :ofid, :organization_foreign_id
 
     def to_params
       ArgParser.named_args.map do |arg|

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -8,13 +8,15 @@ describe Totango::Client do
   it "builds a valid url when sent correct data" do
     valid_url  = "http://sdr.totango.com/pixel.gif/?sdr_s=lolwut"\
                  "&sdr_a=fake+activity&sdr_o=legit+organization"\
-                 "&sdr_m=awesome+module&sdr_u=annoying+user"
+                 "&sdr_m=awesome+module&sdr_u=annoying+user"\
+                 "&sdr_ofid=1234"
 
     @client.build_url({
       :sdr_a => "fake activity",
       :sdr_o => "legit organization",
       :sdr_m => "awesome module",
-      :sdr_u => "annoying user"
+      :sdr_u => "annoying user",
+      :sdr_ofid => "1234"
     }).should eql(valid_url)
   end
 
@@ -39,6 +41,9 @@ describe Totango::Client do
 
     it {@client.build_url(:u => "user").should match(/sdr_u=user/)}
     it {@client.build_url(:user => "user").should match(/sdr_u=user/)}
+
+    it {@client.build_url(:ofid => "org").should match(/sdr_ofid=org/)}
+    it {@client.build_url(:organization_foreign_id => "org").should match(/sdr_ofid=org/)}
   end
 
   describe "Tracking" do


### PR DESCRIPTION
This adds support to the "sdr_ofid" parameter described in the API docs:

http://www.totango.com/developer/api-specification/organization-foreign-id-ofid/
